### PR TITLE
Unstoppable UI update

### DIFF
--- a/src/components/common/AccountBar.vue
+++ b/src/components/common/AccountBar.vue
@@ -16,7 +16,7 @@
                                     @click="hideRubic"
                                     v-bind="attrs"
                                     v-on="on">
-                                {{ accountShort }}
+                                {{ accountDisplay }}
                             </v-chip>
                         </template>
 
@@ -115,7 +115,7 @@ export default {
     },
 
     computed: {
-        ...mapGetters('accountData', ['balance', 'account']),
+        ...mapGetters('accountData', ['balance', 'account', 'uns']),
         ...mapGetters('web3', ['web3',  'networkId', 'walletConnected']),
         ...mapGetters('farmUI', ['showFarm']),
 
@@ -123,8 +123,10 @@ export default {
             return this.walletConnected;
         },
 
-        accountShort: function () {
-            if (this.account) {
+        accountDisplay: function () {
+            if (this.uns) {
+                return this.uns;
+            } else if (this.account) {
                 return this.account.substring(0, 5) + '...' + this.account.substring(this.account.length - 4);
             } else {
                 return null;
@@ -139,7 +141,7 @@ export default {
     created() {
         window.setInterval(() => {
             this.refreshBalance();
-        }, 5000)
+        }, 500000)
     },
 
     methods: {

--- a/src/components/common/AccountBar.vue
+++ b/src/components/common/AccountBar.vue
@@ -141,7 +141,7 @@ export default {
     created() {
         window.setInterval(() => {
             this.refreshBalance();
-        }, 500000)
+        }, 5000)
     },
 
     methods: {

--- a/src/store/modules/common/web3.js
+++ b/src/store/modules/common/web3.js
@@ -151,6 +151,9 @@ const actions = {
                         commit('setWalletName', wallet.name);
                         localStorage.setItem('walletName', wallet.name);
                         console.log(wallet.name + ' is now connected!');
+                        if (wallet.name === 'Unstoppable') {
+                            commit('accountData/setUns', wallet.instance.cacheOptions.getDefaultUsername(), {root:true})
+                        }
                         commit('accountData/setAccount', wallet.address, {root:true});
 
                         dispatch('checkAccount');
@@ -299,8 +302,9 @@ const actions = {
         console.log('Call: resetUserData');
 
         dispatch('accountData/resetBalance', null, {root:true});
+        dispatch('accountData/resetUns', null, {root:true})
         dispatch('dashboardData/resetDashboard', null, {root:true});
-
+       
     },
 
     async updateUserData({commit, dispatch, getters, rootState}) {

--- a/src/store/modules/views/account/data.js
+++ b/src/store/modules/views/account/data.js
@@ -7,6 +7,8 @@ const state = {
 
     account: null,
 
+    uns: null,
+
 };
 
 const getters = {
@@ -18,6 +20,10 @@ const getters = {
     account(state) {
         return state.account;
     },
+
+    uns(state) {
+        return state.uns;
+    }
 
 };
 
@@ -32,6 +38,14 @@ const actions = {
             usdc: 0
         });
 
+    },
+
+    async resetUns({commit, dispatch, getters}) {
+
+        console.log('AccountData: resetUns');
+
+        commit('setUns', null);
+        
     },
 
 
@@ -97,6 +111,10 @@ const mutations = {
     setAccount(state, account) {
         state.account = account;
     },
+
+    setUns(state, uns) {
+        state.uns = uns;
+    }
 };
 
 export default {


### PR DESCRIPTION
## What does it change?
When a user logs in with Unstoppable they see their unstoppable domain name instead of a standard address (0x43..)

## Why?
On my previous pull request I forgot to add this feature

## Video
[Test video on IPFS](https://bafybeihr5xm2mobx6kjkhe57gors3bngc52mhdif5yqvzz5otz65ucftmi.ipfs.dweb.link/overnight-2-test.mp4)

## Modified files
- add uns to accountData store (src/store/modules/views/account/data)
- handle uns set and reset in web3 store (src/store/modules/common/web3.js)
- change accountShort function to accountDisplay, add logic to check for unstoppable name (src/components/common/AccountBar.vue)

